### PR TITLE
Update the engines field of package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "url": "https://github.com/oBusk/read-bigint/issues"
     },
     "engines": {
-        "node": "~10.18.1 || ^10.20.0 || ^12.16.0 || >=14.2.0"
+        "node": ">=10.4.0"
     },
     "volta": {
         "node": "14.4.0"


### PR DESCRIPTION
This library is awesome, but I think there is a small detail that needs to be corrected:

I have tested on node 10.4.0, 10.5.0, 10.15.0, it is available, 10.3.0 is not available, and node supports bigint since 10.4.0, it is necessary to reduce the version number to 10.4 .0, hope to be accepted.